### PR TITLE
Implement responsive design for key pages

### DIFF
--- a/app/common/components/ui/collapsible.tsx
+++ b/app/common/components/ui/collapsible.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import * as CollapsiblePrimitive from '@radix-ui/react-collapsible';
 
 function Collapsible({

--- a/app/features/invitations/pages/invitations-page.tsx
+++ b/app/features/invitations/pages/invitations-page.tsx
@@ -21,7 +21,14 @@ import {
   Gift,
   TrendingUp,
   AlertCircle,
+  ChevronDown,
+  ChevronUp,
 } from 'lucide-react';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '~/common/components/ui/collapsible';
 
 // 컴포넌트 imports
 import { InvitationStatsCards } from '../components/invitation-stats-cards';
@@ -105,41 +112,43 @@ export function meta({ data, params }: Route.MetaArgs) {
   ];
 }
 
-// 빈 상태 컴포넌트
+// 🎨 반응형 빈 상태 컴포넌트
 function EmptyInvitationsState() {
   return (
-    <div className="text-center py-12">
-      <div className="mx-auto w-24 h-24 bg-muted rounded-full flex items-center justify-center mb-6">
-        <Users className="w-12 h-12 text-muted-foreground" />
+    <div className="text-center py-8 px-4">
+      <div className="mx-auto w-20 h-20 sm:w-24 sm:h-24 bg-muted rounded-full flex items-center justify-center mb-4 sm:mb-6">
+        <Users className="w-10 h-10 sm:w-12 sm:h-12 text-muted-foreground" />
       </div>
-      <h3 className="text-lg font-semibold mb-2">추천 코드가 없습니다</h3>
-      <p className="text-muted-foreground mb-6 max-w-md mx-auto">
+      <h3 className="text-lg sm:text-xl font-semibold mb-2">추천 코드가 없습니다</h3>
+      <p className="text-sm sm:text-base text-muted-foreground mb-6 max-w-md mx-auto leading-relaxed">
         동료 추천 코드를 통해 소중한 동료들을 추천하여 함께 성장하세요!
       </p>
       <div className="space-y-4">
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 max-w-xl mx-auto">
-          <Card className="p-4">
+        {/* 🎯 모바일 최적화: 1열 → 2열 적응형 그리드 */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-4 max-w-xl mx-auto">
+          <Card className="p-3 sm:p-4 hover:shadow-md transition-shadow">
             <div className="text-center">
-              <Users className="w-8 h-8 text-green-500 mx-auto mb-2" />
-              <h4 className="font-medium mb-1">전문가 네트워크</h4>
-              <p className="text-sm text-muted-foreground">
+              <Users className="w-6 h-6 sm:w-8 sm:h-8 text-green-500 mx-auto mb-2" />
+              <h4 className="font-medium mb-1 text-sm sm:text-base">전문가 네트워크</h4>
+              <p className="text-xs sm:text-sm text-muted-foreground">
                 동료들과 함께 성장
               </p>
             </div>
           </Card>
-          <Card className="p-4">
+          <Card className="p-3 sm:p-4 hover:shadow-md transition-shadow">
             <div className="text-center">
-              <TrendingUp className="w-8 h-8 text-blue-500 mx-auto mb-2" />
-              <h4 className="font-medium mb-1">비즈니스 성장</h4>
-              <p className="text-sm text-muted-foreground">
+              <TrendingUp className="w-6 h-6 sm:w-8 sm:h-8 text-blue-500 mx-auto mb-2" />
+              <h4 className="font-medium mb-1 text-sm sm:text-base">비즈니스 성장</h4>
+              <p className="text-xs sm:text-sm text-muted-foreground">
                 함께 발전하는 기회
               </p>
             </div>
           </Card>
         </div>
-        <Alert className="max-w-md mx-auto">
+        {/* 🎯 모바일 최적화: Alert 너비 조정 */}
+        <Alert className="max-w-lg mx-auto">
           <AlertCircle className="h-4 w-4" />
-          <AlertDescription>
+          <AlertDescription className="text-sm">
             관리자에게 문의하여 추천 코드를 요청하실 수 있습니다.
           </AlertDescription>
         </Alert>
@@ -148,18 +157,26 @@ function EmptyInvitationsState() {
   );
 }
 
-// 에러 상태 컴포넌트
+// 🎨 반응형 에러 상태 컴포넌트
 function ErrorState({ error }: { error: string }) {
   return (
-    <div className="text-center py-12">
-      <div className="mx-auto w-24 h-24 bg-red-50 rounded-full flex items-center justify-center mb-6">
-        <XCircle className="w-12 h-12 text-red-500" />
+    <div className="text-center py-8 px-4">
+      <div className="mx-auto w-20 h-20 sm:w-24 sm:h-24 bg-red-50 rounded-full flex items-center justify-center mb-4 sm:mb-6">
+        <XCircle className="w-10 h-10 sm:w-12 sm:h-12 text-red-500" />
       </div>
-      <h3 className="text-lg font-semibold mb-2">
+      <h3 className="text-lg sm:text-xl font-semibold mb-2">
         데이터를 불러올 수 없습니다
       </h3>
-      <p className="text-muted-foreground mb-6 max-w-md mx-auto">{error}</p>
-      <Button onClick={() => window.location.reload()} variant="outline">
+      <p className="text-sm sm:text-base text-muted-foreground mb-6 max-w-md mx-auto">
+        {error}
+      </p>
+      {/* 🎯 터치 최적화: 버튼 크기 증가 */}
+      <Button 
+        onClick={() => window.location.reload()} 
+        variant="outline"
+        size="lg"
+        className="min-h-[44px]"
+      >
         다시 시도
       </Button>
     </div>
@@ -170,6 +187,7 @@ export default function InvitationsPage({ loaderData }: Route.ComponentProps) {
   const { myInvitations, invitationStats, invitedColleagues, hasData, error } =
     loaderData;
   const [copiedCode, setCopiedCode] = useState<string | null>(null);
+  const [isGuideOpen, setIsGuideOpen] = useState(false);
 
   const availableInvitations = myInvitations.filter(
     (inv: Invitation) => inv.status === 'available'
@@ -206,30 +224,32 @@ export default function InvitationsPage({ loaderData }: Route.ComponentProps) {
 
   return (
     <MainLayout title="동료 추천">
-      <div className="space-y-6">
-        {/* 헤더 */}
-        <div>
-          <p className="text-muted-foreground">
+      <div className="space-y-4 sm:space-y-6 px-2 sm:px-0">
+        {/* 🎯 모바일 최적화: 헤더 */}
+        <div className="space-y-2">
+          <p className="text-sm sm:text-base text-muted-foreground leading-relaxed">
             소중한 동료들을 SureCRM에 추천하고 함께 성장하세요. 추천 코드를 통해
             전문가 네트워크를 확장하세요.
           </p>
         </div>
 
-        {/* 추천 코드 현황 요약 */}
+        {/* 🎯 모바일 최적화: 추천 코드 현황 요약 (기존 컴포넌트 사용) */}
         <InvitationStatsCards
           availableCount={invitationStats.availableInvitations}
           usedInvitations={usedInvitations}
         />
 
-        {/* 내 추천 코드들 */}
-        <div className="space-y-4">
+        {/* 🎯 모바일 최적화: 내 추천 코드들 */}
+        <div className="space-y-3 sm:space-y-4">
           <div className="flex items-center justify-between">
-            <h3 className="text-lg font-medium">내 추천 코드</h3>
-            <Badge variant="outline">{myInvitations.length}개 보유</Badge>
+            <h3 className="text-lg sm:text-xl font-medium">내 추천 코드</h3>
+            <Badge variant="outline" className="text-xs sm:text-sm px-2 py-1">
+              {myInvitations.length}개 보유
+            </Badge>
           </div>
 
           {myInvitations.length > 0 ? (
-            <div className="grid gap-4">
+            <div className="space-y-3 sm:space-y-4">
               {myInvitations.map((invitation: Invitation) => (
                 <InvitationCard
                   key={invitation.id}
@@ -241,10 +261,10 @@ export default function InvitationsPage({ loaderData }: Route.ComponentProps) {
             </div>
           ) : (
             <Card>
-              <CardContent className="text-center py-8">
-                <Users className="w-12 h-12 text-muted-foreground mx-auto mb-4" />
-                <h4 className="font-medium mb-2">추천 코드가 없습니다</h4>
-                <p className="text-sm text-muted-foreground mb-4">
+              <CardContent className="text-center py-6 sm:py-8 px-4">
+                <Users className="w-10 h-10 sm:w-12 sm:h-12 text-muted-foreground mx-auto mb-3 sm:mb-4" />
+                <h4 className="font-medium mb-2 text-sm sm:text-base">추천 코드가 없습니다</h4>
+                <p className="text-xs sm:text-sm text-muted-foreground mb-4">
                   관리자에게 문의하여 추천 코드를 요청하실 수 있습니다.
                 </p>
               </CardContent>
@@ -257,19 +277,19 @@ export default function InvitationsPage({ loaderData }: Route.ComponentProps) {
           )}
         </div>
 
-        {/* 내가 추천한 사람들 */}
+        {/* 🎯 모바일 최적화: 내가 추천한 사람들 */}
         {invitedColleagues.length > 0 ? (
           <InvitedColleagues usedInvitations={invitedColleagues} />
         ) : (
-          <div className="space-y-4">
-            <h3 className="text-lg font-medium">추천한 동료들</h3>
+          <div className="space-y-3 sm:space-y-4">
+            <h3 className="text-lg sm:text-xl font-medium">추천한 동료들</h3>
             <Card>
-              <CardContent className="text-center py-8">
-                <CheckCircle className="w-12 h-12 text-muted-foreground mx-auto mb-4" />
-                <h4 className="font-medium mb-2">
+              <CardContent className="text-center py-6 sm:py-8 px-4">
+                <CheckCircle className="w-10 h-10 sm:w-12 sm:h-12 text-muted-foreground mx-auto mb-3 sm:mb-4" />
+                <h4 className="font-medium mb-2 text-sm sm:text-base">
                   아직 추천한 동료가 없습니다
                 </h4>
-                <p className="text-sm text-muted-foreground">
+                <p className="text-xs sm:text-sm text-muted-foreground">
                   추천 코드를 공유하여 동료들을 SureCRM에 추천해보세요.
                 </p>
               </CardContent>
@@ -277,37 +297,50 @@ export default function InvitationsPage({ loaderData }: Route.ComponentProps) {
           </div>
         )}
 
-        {/* 추천 가이드 */}
-        <Card className="border-border/40 bg-muted/20 backdrop-blur-sm">
-          <CardHeader>
-            <CardTitle className="text-foreground flex items-center gap-2">
-              <div className="w-8 h-8 rounded-full bg-primary/10 flex items-center justify-center">
-                💡
-              </div>
-              추천 가이드
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-3 text-sm">
-            <div className="flex items-start gap-3 p-3 rounded-lg bg-card/50 border border-border/30">
-              <div className="w-2 h-2 rounded-full bg-primary/60 mt-2 flex-shrink-0" />
-              <p className="text-muted-foreground">
-                추천 코드는 관리자를 통해 발급받을 수 있습니다
-              </p>
-            </div>
-            <div className="flex items-start gap-3 p-3 rounded-lg bg-card/50 border border-border/30">
-              <div className="w-2 h-2 rounded-full bg-primary/60 mt-2 flex-shrink-0" />
-              <p className="text-muted-foreground">
-                추천 코드는 영구적으로 유효하며 만료되지 않습니다
-              </p>
-            </div>
-            <div className="flex items-start gap-3 p-3 rounded-lg bg-card/50 border border-border/30">
-              <div className="w-2 h-2 rounded-full bg-primary/60 mt-2 flex-shrink-0" />
-              <p className="text-muted-foreground">
-                소중한 동료들에게만 추천 코드를 공유하시기 바랍니다
-              </p>
-            </div>
-          </CardContent>
-        </Card>
+        {/* 🎯 모바일 최적화: 접기/펼치기 가능한 추천 가이드 */}
+        <Collapsible open={isGuideOpen} onOpenChange={setIsGuideOpen}>
+          <Card className="border-border/40 bg-muted/20 backdrop-blur-sm">
+            <CollapsibleTrigger asChild>
+              <CardHeader className="cursor-pointer hover:bg-muted/30 transition-colors rounded-t-lg">
+                <CardTitle className="text-foreground flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <div className="w-8 h-8 rounded-full bg-primary/10 flex items-center justify-center">
+                      💡
+                    </div>
+                    <span className="text-base sm:text-lg">추천 가이드</span>
+                  </div>
+                  {isGuideOpen ? (
+                    <ChevronUp className="h-4 w-4 sm:h-5 sm:w-5" />
+                  ) : (
+                    <ChevronDown className="h-4 w-4 sm:h-5 sm:w-5" />
+                  )}
+                </CardTitle>
+              </CardHeader>
+            </CollapsibleTrigger>
+            <CollapsibleContent>
+              <CardContent className="space-y-3 text-sm pt-0">
+                <div className="flex items-start gap-3 p-3 rounded-lg bg-card/50 border border-border/30">
+                  <div className="w-2 h-2 rounded-full bg-primary/60 mt-2 flex-shrink-0" />
+                  <p className="text-muted-foreground leading-relaxed">
+                    추천 코드는 관리자를 통해 발급받을 수 있습니다
+                  </p>
+                </div>
+                <div className="flex items-start gap-3 p-3 rounded-lg bg-card/50 border border-border/30">
+                  <div className="w-2 h-2 rounded-full bg-primary/60 mt-2 flex-shrink-0" />
+                  <p className="text-muted-foreground leading-relaxed">
+                    추천 코드는 영구적으로 유효하며 만료되지 않습니다
+                  </p>
+                </div>
+                <div className="flex items-start gap-3 p-3 rounded-lg bg-card/50 border border-border/30">
+                  <div className="w-2 h-2 rounded-full bg-primary/60 mt-2 flex-shrink-0" />
+                  <p className="text-muted-foreground leading-relaxed">
+                    소중한 동료들에게만 추천 코드를 공유하시기 바랍니다
+                  </p>
+                </div>
+              </CardContent>
+            </CollapsibleContent>
+          </Card>
+        </Collapsible>
       </div>
     </MainLayout>
   );

--- a/app/features/notifications/pages/notifications-page.tsx
+++ b/app/features/notifications/pages/notifications-page.tsx
@@ -313,55 +313,55 @@ export default function NotificationsPage({
 
   return (
     <MainLayout title="알림">
-      <div className="space-y-6">
-        {/* 상단 요약 카드 */}
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+      <div className="space-y-4 sm:space-y-6 px-2 sm:px-0">
+        {/* 🎯 모바일 최적화: 상단 요약 카드 */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 sm:gap-4">
           <Card>
-            <CardContent className="flex items-center p-6">
+            <CardContent className="flex items-center p-4 sm:p-6">
               <div
-                className={`p-3 rounded-full ${getPriorityColor(
+                className={`p-2 sm:p-3 rounded-full ${getPriorityColor(
                   'normal'
-                )} mr-4`}
+                )} mr-3 sm:mr-4`}
               >
-                <Bell className="h-6 w-6 text-white" />
+                <Bell className="h-5 w-5 sm:h-6 sm:w-6 text-white" />
               </div>
               <div>
-                <p className="text-sm font-medium text-muted-foreground">
+                <p className="text-xs sm:text-sm font-medium text-muted-foreground">
                   전체 알림
                 </p>
-                <p className="text-2xl font-bold">{notifications.length}</p>
+                <p className="text-xl sm:text-2xl font-bold">{notifications.length}</p>
               </div>
             </CardContent>
           </Card>
 
           <Card>
-            <CardContent className="flex items-center p-6">
+            <CardContent className="flex items-center p-4 sm:p-6">
               <div
-                className={`p-3 rounded-full ${getPriorityColor('high')} mr-4`}
+                className={`p-2 sm:p-3 rounded-full ${getPriorityColor('high')} mr-3 sm:mr-4`}
               >
-                <AlertTriangle className="h-6 w-6 text-white" />
+                <AlertTriangle className="h-5 w-5 sm:h-6 sm:w-6 text-white" />
               </div>
               <div>
-                <p className="text-sm font-medium text-muted-foreground">
+                <p className="text-xs sm:text-sm font-medium text-muted-foreground">
                   읽지 않음
                 </p>
-                <p className="text-2xl font-bold">{unreadCount}</p>
+                <p className="text-xl sm:text-2xl font-bold">{unreadCount}</p>
               </div>
             </CardContent>
           </Card>
 
-          <Card>
-            <CardContent className="flex items-center p-6">
+          <Card className="sm:col-span-2 lg:col-span-1">
+            <CardContent className="flex items-center p-4 sm:p-6">
               <div
-                className={`p-3 rounded-full ${getPriorityColor('low')} mr-4`}
+                className={`p-2 sm:p-3 rounded-full ${getPriorityColor('low')} mr-3 sm:mr-4`}
               >
-                <CheckCircle className="h-6 w-6 text-white" />
+                <CheckCircle className="h-5 w-5 sm:h-6 sm:w-6 text-white" />
               </div>
               <div>
-                <p className="text-sm font-medium text-muted-foreground">
+                <p className="text-xs sm:text-sm font-medium text-muted-foreground">
                   완료율
                 </p>
-                <p className="text-2xl font-bold">
+                <p className="text-xl sm:text-2xl font-bold">
                   {notifications.length > 0
                     ? Math.round(
                         ((notifications.length - unreadCount) /
@@ -376,19 +376,20 @@ export default function NotificationsPage({
           </Card>
         </div>
 
-        {/* 알림 목록 */}
+        {/* 🎯 모바일 최적화: 알림 목록 */}
         <Card>
-          <CardHeader className="flex flex-row items-center justify-between">
-            <CardTitle className="flex items-center gap-2">
-              <Bell className="h-5 w-5" />
+          <CardHeader className="flex flex-col sm:flex-row items-start sm:items-center justify-between space-y-2 sm:space-y-0 p-4 sm:p-6">
+            <CardTitle className="flex items-center gap-2 text-base sm:text-lg">
+              <Bell className="h-4 w-4 sm:h-5 sm:w-5" />
               최근 알림
             </CardTitle>
-            <div className="flex gap-2">
+            <div className="flex gap-2 w-full sm:w-auto">
               {notifications.length > 0 && (
                 <Button
                   variant="outline"
                   size="sm"
                   onClick={handleMarkAllAsRead}
+                  className="min-h-[44px] px-3 sm:px-4 text-sm flex-1 sm:flex-initial"
                 >
                   <CheckCircle className="h-4 w-4 mr-2" />
                   모두 읽음
@@ -396,9 +397,9 @@ export default function NotificationsPage({
               )}
             </div>
           </CardHeader>
-          <CardContent>
+          <CardContent className="p-4 sm:p-6 pt-0">
             {notifications.length > 0 ? (
-              <div className="space-y-4">
+              <div className="space-y-3 sm:space-y-4">
                 {/* 🎯 읽지 않은 알림과 읽은 알림을 구분하여 표시 */}
                 {(() => {
                   const unreadNotifications = notifications.filter(
@@ -410,7 +411,7 @@ export default function NotificationsPage({
                     <>
                       {/* 읽지 않은 알림 섹션 */}
                       {unreadNotifications.length > 0 && (
-                        <div className="space-y-4">
+                        <div className="space-y-3 sm:space-y-4">
                           <div className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
                             <span className="w-2 h-2 bg-blue-500 rounded-full animate-pulse"></span>
                             읽지 않은 알림 ({unreadNotifications.length}개)
@@ -418,7 +419,7 @@ export default function NotificationsPage({
                           {unreadNotifications.map(notification => (
                             <div
                               key={notification.id}
-                              className="group flex items-start gap-4 p-4 border rounded-lg transition-all cursor-pointer hover:bg-muted/50 hover:shadow-sm hover:border-primary/40 bg-muted/20 border-primary/20"
+                              className="group flex items-start gap-3 sm:gap-4 p-3 sm:p-4 border rounded-lg transition-all cursor-pointer hover:bg-muted/50 hover:shadow-sm hover:border-primary/40 bg-muted/20 border-primary/20 min-h-[60px] sm:min-h-[72px]"
                               onClick={() =>
                                 handleToggleRead(
                                   notification.id,
@@ -427,23 +428,23 @@ export default function NotificationsPage({
                               }
                               title="클릭하여 읽음으로 표시"
                             >
-                              {/* 알림 아이콘 */}
+                              {/* 🎯 모바일 최적화: 알림 아이콘 */}
                               <div
                                 className={`p-2 rounded-full ${getPriorityColor(
                                   notification.priority
-                                )}`}
+                                )} flex-shrink-0`}
                               >
                                 {getNotificationIcon(notification.type)}
                               </div>
 
-                              {/* 알림 내용 */}
+                              {/* 🎯 모바일 최적화: 알림 내용 */}
                               <div className="flex-1 min-w-0">
                                 <div className="flex items-start justify-between gap-2">
-                                  <h4 className="text-sm leading-tight font-semibold text-foreground">
+                                  <h4 className="text-sm sm:text-base leading-tight font-semibold text-foreground pr-2">
                                     {notification.title}
                                     <span className="ml-2 inline-flex items-center justify-center w-2 h-2 bg-blue-500 rounded-full animate-pulse" />
                                   </h4>
-                                  <div className="flex items-center gap-2 flex-shrink-0">
+                                  <div className="flex items-center gap-1 sm:gap-2 flex-shrink-0">
                                     {getStatusBadge(
                                       notification.status,
                                       notification.readAt
@@ -451,20 +452,20 @@ export default function NotificationsPage({
                                     <Button
                                       variant="ghost"
                                       size="sm"
-                                      className="h-6 w-6 p-0"
+                                      className="h-8 w-8 sm:h-9 sm:w-9 p-0 min-h-[32px] sm:min-h-[36px]"
                                       onClick={e => {
                                         e.stopPropagation();
                                         handleDelete(notification.id);
                                       }}
                                     >
-                                      <Trash2 className="h-3 w-3" />
+                                      <Trash2 className="h-3 w-3 sm:h-4 sm:w-4" />
                                     </Button>
                                   </div>
                                 </div>
-                                <p className="text-sm mt-1 line-clamp-2 text-foreground">
+                                <p className="text-xs sm:text-sm mt-1 line-clamp-2 text-foreground leading-relaxed">
                                   {notification.message}
                                 </p>
-                                <div className="flex items-center gap-4 mt-2 text-xs text-muted-foreground">
+                                <div className="flex items-center gap-2 sm:gap-4 mt-2 text-xs text-muted-foreground">
                                   <span className="flex items-center gap-1">
                                     <Clock className="h-3 w-3" />
                                     {new Date(
@@ -479,7 +480,7 @@ export default function NotificationsPage({
                                   {notification.channel && (
                                     <Badge
                                       variant="outline"
-                                      className="text-xs"
+                                      className="text-xs hidden sm:inline-flex"
                                     >
                                       {notification.channel}
                                     </Badge>
@@ -493,9 +494,9 @@ export default function NotificationsPage({
 
                       {/* 읽은 알림 섹션 */}
                       {readNotifications.length > 0 && (
-                        <div className="space-y-4">
+                        <div className="space-y-3 sm:space-y-4">
                           {unreadNotifications.length > 0 && (
-                            <div className="flex items-center gap-2 text-sm font-medium text-muted-foreground pt-4 border-t">
+                            <div className="flex items-center gap-2 text-sm font-medium text-muted-foreground pt-3 sm:pt-4 border-t">
                               <CheckCircle className="w-4 h-4" />
                               읽은 알림 ({readNotifications.length}개)
                             </div>
@@ -503,7 +504,7 @@ export default function NotificationsPage({
                           {readNotifications.map(notification => (
                             <div
                               key={notification.id}
-                              className="group flex items-start gap-4 p-4 border rounded-lg transition-all cursor-pointer hover:bg-muted/50 hover:shadow-sm hover:border-primary/40"
+                              className="group flex items-start gap-3 sm:gap-4 p-3 sm:p-4 border rounded-lg transition-all cursor-pointer hover:bg-muted/50 hover:shadow-sm hover:border-primary/40 min-h-[60px] sm:min-h-[72px]"
                               onClick={() =>
                                 handleToggleRead(
                                   notification.id,
@@ -512,22 +513,22 @@ export default function NotificationsPage({
                               }
                               title="클릭하여 읽지 않음으로 표시"
                             >
-                              {/* 알림 아이콘 */}
+                              {/* 🎯 모바일 최적화: 알림 아이콘 */}
                               <div
                                 className={`p-2 rounded-full ${getPriorityColor(
                                   notification.priority
-                                )} opacity-75`}
+                                )} opacity-75 flex-shrink-0`}
                               >
                                 {getNotificationIcon(notification.type)}
                               </div>
 
-                              {/* 알림 내용 */}
+                              {/* 🎯 모바일 최적화: 알림 내용 */}
                               <div className="flex-1 min-w-0">
                                 <div className="flex items-start justify-between gap-2">
-                                  <h4 className="text-sm leading-tight font-normal text-muted-foreground">
+                                  <h4 className="text-sm sm:text-base leading-tight font-normal text-muted-foreground pr-2">
                                     {notification.title}
                                   </h4>
-                                  <div className="flex items-center gap-2 flex-shrink-0">
+                                  <div className="flex items-center gap-1 sm:gap-2 flex-shrink-0">
                                     {getStatusBadge(
                                       notification.status,
                                       notification.readAt
@@ -535,20 +536,20 @@ export default function NotificationsPage({
                                     <Button
                                       variant="ghost"
                                       size="sm"
-                                      className="h-6 w-6 p-0"
+                                      className="h-8 w-8 sm:h-9 sm:w-9 p-0 min-h-[32px] sm:min-h-[36px]"
                                       onClick={e => {
                                         e.stopPropagation();
                                         handleDelete(notification.id);
                                       }}
                                     >
-                                      <Trash2 className="h-3 w-3" />
+                                      <Trash2 className="h-3 w-3 sm:h-4 sm:w-4" />
                                     </Button>
                                   </div>
                                 </div>
-                                <p className="text-sm mt-1 line-clamp-2 text-muted-foreground">
+                                <p className="text-xs sm:text-sm mt-1 line-clamp-2 text-muted-foreground leading-relaxed">
                                   {notification.message}
                                 </p>
-                                <div className="flex items-center gap-4 mt-2 text-xs text-muted-foreground">
+                                <div className="flex items-center gap-2 sm:gap-4 mt-2 text-xs text-muted-foreground">
                                   <span className="flex items-center gap-1">
                                     <Clock className="h-3 w-3" />
                                     {new Date(
@@ -563,7 +564,7 @@ export default function NotificationsPage({
                                   {notification.channel && (
                                     <Badge
                                       variant="outline"
-                                      className="text-xs"
+                                      className="text-xs hidden sm:inline-flex"
                                     >
                                       {notification.channel}
                                     </Badge>
@@ -579,20 +580,20 @@ export default function NotificationsPage({
                 })()}
               </div>
             ) : (
-              // 빈 상태 UI 개선
-              <div className="text-center py-12">
-                <div className="mx-auto w-24 h-24 bg-muted rounded-full flex items-center justify-center mb-4">
-                  <Bell className="h-12 w-12 text-muted-foreground" />
+              // 🎯 모바일 최적화: 빈 상태 UI 개선
+              <div className="text-center py-8 sm:py-12 px-4">
+                <div className="mx-auto w-20 h-20 sm:w-24 sm:h-24 bg-muted rounded-full flex items-center justify-center mb-4">
+                  <Bell className="h-10 w-10 sm:h-12 sm:w-12 text-muted-foreground" />
                 </div>
-                <h3 className="text-lg font-semibold mb-2">알림이 없습니다</h3>
-                <p className="text-muted-foreground mb-4">
+                <h3 className="text-lg sm:text-xl font-semibold mb-2">알림이 없습니다</h3>
+                <p className="text-sm sm:text-base text-muted-foreground mb-4 max-w-md mx-auto leading-relaxed">
                   {user
                     ? `${
                         user.fullName || user.email
                       }님, 모든 알림을 확인했습니다.`
                     : '새로운 알림이 있으면 여기에 표시됩니다.'}
                 </p>
-                <div className="text-xs text-muted-foreground space-y-1">
+                <div className="text-xs sm:text-sm text-muted-foreground space-y-1 max-w-sm mx-auto">
                   <p>🎂 고객 생일, 📈 파이프라인 변화, 📅 미팅 일정 등</p>
                   <p>중요한 알림들이 자동으로 생성되어 표시됩니다.</p>
                 </div>

--- a/app/features/reports/pages/reports-page.tsx
+++ b/app/features/reports/pages/reports-page.tsx
@@ -296,25 +296,25 @@ export default function ReportsPage({ loaderData }: Route.ComponentProps) {
 
   return (
     <MainLayout title="보고서">
-      <div className="space-y-6">
-        {/* 헤더 */}
-        <div className="flex items-center justify-between">
-          <div>
-            <p className="text-muted-foreground">
+      <div className="space-y-4 sm:space-y-6 px-2 sm:px-0">
+        {/* 🎯 모바일 최적화: 헤더 */}
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between space-y-3 sm:space-y-0">
+          <div className="space-y-1">
+            <p className="text-sm sm:text-base text-muted-foreground leading-relaxed">
               비즈니스 성과와 주요 지표를 확인하세요
             </p>
-            <p className="text-sm text-muted-foreground mt-1">
-              <Calendar className="inline h-4 w-4 mr-1" />
+            <p className="text-xs sm:text-sm text-muted-foreground flex items-center">
+              <Calendar className="inline h-3 w-3 sm:h-4 sm:w-4 mr-1" />
               {dateRange.formatted}
             </p>
           </div>
-          <div className="flex items-center gap-3">
+          <div className="flex items-center gap-2 sm:gap-3 w-full sm:w-auto">
             <Select
               value={selectedPeriod}
               onValueChange={handlePeriodChange}
               disabled={isLoading}
             >
-              <SelectTrigger className="w-32">
+              <SelectTrigger className="w-full sm:w-32 min-h-[44px]">
                 <SelectValue />
                 {isLoading && (
                   <RefreshCw className="ml-2 h-4 w-4 animate-spin" />
@@ -327,14 +327,20 @@ export default function ReportsPage({ loaderData }: Route.ComponentProps) {
                 <SelectItem value="year">올해</SelectItem>
               </SelectContent>
             </Select>
-            <Button variant="outline" size="sm" onClick={handleDownload}>
-              <Download className="mr-2 h-4 w-4" />
-              다운로드
+            <Button 
+              variant="outline" 
+              size="sm" 
+              onClick={handleDownload}
+              className="min-h-[44px] px-3 sm:px-4 flex-shrink-0"
+            >
+              <Download className="mr-1 sm:mr-2 h-4 w-4" />
+              <span className="hidden sm:inline">다운로드</span>
+              <span className="sm:hidden">저장</span>
             </Button>
           </div>
         </div>
 
-        {/* 핵심 지표 카드들 */}
+        {/* 🎯 모바일 최적화: 핵심 지표 카드들 */}
         <PerformanceMetrics
           performance={performance}
           period={{
@@ -345,14 +351,14 @@ export default function ReportsPage({ loaderData }: Route.ComponentProps) {
           }}
         />
 
-        {/* 카카오톡 업무 보고 양식 */}
+        {/* 🎯 모바일 최적화: 카카오톡 업무 보고 양식 */}
         <KakaoReport
           performance={performance}
           user={user}
           period={selectedPeriod}
         />
 
-        {/* 비즈니스 인사이트 탭 - 🔧 수정: userGoals 전달 */}
+        {/* 🎯 모바일 최적화: 비즈니스 인사이트 탭 - 🔧 수정: userGoals 전달 */}
         <InsightsTabs
           performance={performance}
           topPerformers={topPerformers}

--- a/app/features/settings/pages/settings-page.tsx
+++ b/app/features/settings/pages/settings-page.tsx
@@ -594,7 +594,7 @@ export default function SettingsPage({
 
   return (
     <MainLayout title="설정">
-      <div className="space-y-6">
+      <div className="space-y-4 sm:space-y-6 px-2 sm:px-0">
         {/* 성공/오류 메시지 - 더 세련된 디자인 */}
         {actionData && (
           <div
@@ -604,7 +604,7 @@ export default function SettingsPage({
                 : 'bg-destructive/10 text-destructive border-destructive/30'
             }`}
           >
-            <div className="flex items-center gap-3 p-4">
+            <div className="flex items-center gap-3 p-3 sm:p-4">
               <div
                 className={`p-2 rounded-full ${
                   actionData.success ? 'bg-primary/20' : 'bg-destructive/20'
@@ -617,7 +617,7 @@ export default function SettingsPage({
                 )}
               </div>
               <div className="flex-1">
-                <p className="font-medium">
+                <p className="font-medium text-sm sm:text-base">
                   {actionData.success
                     ? (actionData as any).message
                     : (actionData as any).error}
@@ -627,26 +627,26 @@ export default function SettingsPage({
           </div>
         )}
 
-        {/* 헤더 - 더 임팩트 있게 */}
+        {/* 🎯 모바일 최적화: 헤더 - 더 임팩트 있게 */}
         <div className="relative">
-          <div className="relative bg-card border rounded-xl p-6">
-            <div className="flex items-center justify-between">
+          <div className="relative bg-card border rounded-xl p-4 sm:p-6">
+            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between space-y-3 sm:space-y-0">
               <div className="space-y-2">
                 <div className="flex items-center gap-3">
-                  <div className="p-3 bg-muted rounded-xl">
-                    <SettingsIcon className="h-6 w-6 text-foreground" />
+                  <div className="p-2 sm:p-3 bg-muted rounded-xl">
+                    <SettingsIcon className="h-5 w-5 sm:h-6 sm:w-6 text-foreground" />
                   </div>
                   <div>
-                    <h1 className="text-3xl font-bold text-foreground">설정</h1>
-                    <p className="text-muted-foreground">
+                    <h1 className="text-2xl sm:text-3xl font-bold text-foreground">설정</h1>
+                    <p className="text-sm sm:text-base text-muted-foreground">
                       {user ? `${user.fullName || user.email}님의 ` : ''}계정
                       정보와 환경설정을 관리하세요
                     </p>
                   </div>
                 </div>
               </div>
-              <div className="flex items-center gap-3">
-                <Badge variant="outline" className="px-4 py-2">
+              <div className="flex items-center gap-3 justify-start sm:justify-end">
+                <Badge variant="outline" className="px-3 sm:px-4 py-2">
                   <Crown className="h-3 w-3 mr-2" />
                   MVP 버전
                 </Badge>
@@ -655,23 +655,23 @@ export default function SettingsPage({
           </div>
         </div>
 
-        {/* 메인 설정 - 프로필 정보와 보안 설정 */}
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-          {/* 프로필 정보 */}
+        {/* 🎯 모바일 최적화: 메인 설정 - 프로필 정보와 보안 설정 */}
+        <div className="grid grid-cols-1 xl:grid-cols-2 gap-4 sm:gap-6">
+          {/* 🎯 모바일 최적화: 프로필 정보 */}
           <Card className="border bg-card">
-            <CardHeader>
-              <CardTitle className="flex items-center gap-3 text-lg font-semibold">
+            <CardHeader className="p-4 sm:p-6 pb-3 sm:pb-4">
+              <CardTitle className="flex items-center gap-3 text-base sm:text-lg font-semibold">
                 <div className="p-2 bg-muted rounded-lg">
-                  <User className="h-5 w-5 text-foreground" />
+                  <User className="h-4 w-4 sm:h-5 sm:w-5 text-foreground" />
                 </div>
                 프로필 정보
               </CardTitle>
             </CardHeader>
-            <CardContent className="p-6 space-y-6">
-              <Form method="post" className="space-y-5">
+            <CardContent className="p-4 sm:p-6 pt-0 space-y-5 sm:space-y-6">
+              <Form method="post" className="space-y-4 sm:space-y-5">
                 <input type="hidden" name="actionType" value="updateProfile" />
 
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div className="grid grid-cols-1 gap-4">
                   <div className="space-y-2">
                     <Label
                       htmlFor="name"
@@ -688,7 +688,7 @@ export default function SettingsPage({
                           handleProfileChange('name', e.target.value)
                         }
                         placeholder="이름을 입력하세요"
-                        className="bg-background border"
+                        className="bg-background border min-h-[44px]"
                       />
                     </div>
                   </div>
@@ -704,7 +704,7 @@ export default function SettingsPage({
                         id="position"
                         value={profileData.position}
                         placeholder="직책"
-                        className="bg-muted/50 border-white/10 text-muted-foreground cursor-not-allowed"
+                        className="bg-muted/50 border-white/10 text-muted-foreground cursor-not-allowed min-h-[44px]"
                         readOnly
                       />
                       <Badge className="absolute right-2 top-2 text-xs bg-muted text-muted-foreground">
@@ -728,7 +728,7 @@ export default function SettingsPage({
                       type="email"
                       value={profileData.email}
                       placeholder="이메일"
-                      className="bg-muted/50 border-white/10 text-muted-foreground cursor-not-allowed pl-10"
+                      className="bg-muted/50 border-white/10 text-muted-foreground cursor-not-allowed pl-10 min-h-[44px]"
                       readOnly
                     />
                     <Mail className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
@@ -755,7 +755,7 @@ export default function SettingsPage({
                         handleProfileChange('phone', e.target.value)
                       }
                       placeholder="전화번호를 입력하세요"
-                      className="bg-background border pl-10"
+                      className="bg-background border pl-10 min-h-[44px]"
                     />
                     <Phone className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
                   </div>
@@ -778,13 +778,13 @@ export default function SettingsPage({
                         handleProfileChange('company', e.target.value)
                       }
                       placeholder="회사명을 입력하세요"
-                      className="bg-background border pl-10"
+                      className="bg-background border pl-10 min-h-[44px]"
                     />
                     <Building className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
                   </div>
                 </div>
 
-                <Button type="submit" className="w-full">
+                <Button type="submit" className="w-full min-h-[44px]">
                   <Save className="h-4 w-4 mr-2" />
                   프로필 저장
                 </Button>
@@ -792,18 +792,18 @@ export default function SettingsPage({
             </CardContent>
           </Card>
 
-          {/* 보안 설정 */}
+          {/* 🎯 모바일 최적화: 보안 설정 */}
           <Card className="border bg-card">
-            <CardHeader>
-              <CardTitle className="flex items-center gap-3 text-lg font-semibold">
+            <CardHeader className="p-4 sm:p-6 pb-3 sm:pb-4">
+              <CardTitle className="flex items-center gap-3 text-base sm:text-lg font-semibold">
                 <div className="p-2 bg-muted rounded-lg">
-                  <Shield className="h-5 w-5 text-foreground" />
+                  <Shield className="h-4 w-4 sm:h-5 sm:w-5 text-foreground" />
                 </div>
                 보안 설정
               </CardTitle>
             </CardHeader>
-            <CardContent className="p-6 space-y-6">
-              <Form method="post" className="space-y-5">
+            <CardContent className="p-4 sm:p-6 pt-0 space-y-5 sm:space-y-6">
+              <Form method="post" className="space-y-4 sm:space-y-5">
                 <input type="hidden" name="actionType" value="changePassword" />
 
                 <div className="space-y-4">
@@ -819,7 +819,7 @@ export default function SettingsPage({
                         handlePasswordChange('currentPassword', e.target.value)
                       }
                       placeholder="현재 비밀번호를 입력하세요"
-                      className="bg-background border"
+                      className="bg-background border min-h-[44px]"
                     />
                   </div>
 
@@ -835,7 +835,7 @@ export default function SettingsPage({
                         handlePasswordChange('newPassword', e.target.value)
                       }
                       placeholder="새 비밀번호를 입력하세요 (6자 이상)"
-                      className="bg-background border"
+                      className="bg-background border min-h-[44px]"
                     />
                   </div>
 
@@ -851,19 +851,19 @@ export default function SettingsPage({
                         handlePasswordChange('confirmPassword', e.target.value)
                       }
                       placeholder="새 비밀번호를 다시 입력하세요"
-                      className="bg-background border"
+                      className="bg-background border min-h-[44px]"
                     />
                   </div>
                 </div>
 
-                <Button type="submit" variant="destructive" className="w-full">
+                <Button type="submit" variant="destructive" className="w-full min-h-[44px]">
                   <Shield className="h-4 w-4 mr-2" />
                   비밀번호 변경
                 </Button>
               </Form>
 
               {/* 보안 가이드 */}
-              <div className="mt-6 p-4 bg-muted/50 border rounded-lg">
+              <div className="mt-4 sm:mt-6 p-3 sm:p-4 bg-muted/50 border rounded-lg">
                 <div className="flex items-start gap-3">
                   <Shield className="h-4 w-4 text-foreground mt-0.5" />
                   <div className="space-y-1">
@@ -882,23 +882,23 @@ export default function SettingsPage({
           </Card>
         </div>
 
-        {/* 🌐 연동 설정 - 알림 및 구글 캘린더 */}
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-          {/* 알림 설정 */}
+        {/* � 모바일 최적화: �🌐 연동 설정 - 알림 및 구글 캘린더 */}
+        <div className="grid grid-cols-1 xl:grid-cols-2 gap-4 sm:gap-6">
+          {/* 🎯 모바일 최적화: 알림 설정 */}
           <Card className="border bg-card">
-            <CardHeader>
-              <CardTitle className="flex items-center gap-3 text-lg font-semibold">
+            <CardHeader className="p-4 sm:p-6 pb-3 sm:pb-4">
+              <CardTitle className="flex items-center gap-3 text-base sm:text-lg font-semibold">
                 <div className="p-2 bg-muted rounded-lg">
-                  <Bell className="h-5 w-5 text-foreground" />
+                  <Bell className="h-4 w-4 sm:h-5 sm:w-5 text-foreground" />
                 </div>
                 알림 설정
               </CardTitle>
-              <CardDescription>
+              <CardDescription className="text-sm">
                 이메일 및 시스템 알림 설정을 관리하세요
               </CardDescription>
             </CardHeader>
-            <CardContent className="p-6 space-y-6">
-              <Form method="post" className="space-y-5">
+            <CardContent className="p-4 sm:p-6 pt-0 space-y-5 sm:space-y-6">
+              <Form method="post" className="space-y-4 sm:space-y-5">
                 <input
                   type="hidden"
                   name="actionType"
@@ -906,7 +906,7 @@ export default function SettingsPage({
                 />
 
                 <div className="space-y-4">
-                  <div className="flex items-start justify-between">
+                  <div className="flex items-start justify-between min-h-[44px]">
                     <div className="space-y-1 flex-1 mr-4">
                       <Label
                         htmlFor="emailNotifications"
@@ -923,19 +923,19 @@ export default function SettingsPage({
                       name="emailNotifications"
                       checked={emailNotifications}
                       onCheckedChange={setEmailNotifications}
-                      className="flex-shrink-0"
+                      className="flex-shrink-0 mt-1"
                     />
                   </div>
                 </div>
 
-                <Button type="submit" className="w-full">
+                <Button type="submit" className="w-full min-h-[44px]">
                   <Save className="h-4 w-4 mr-2" />
                   알림 설정 저장
                 </Button>
               </Form>
 
               {/* 알림 가이드 */}
-              <div className="mt-6 p-4 bg-muted/50 border rounded-lg">
+              <div className="mt-4 sm:mt-6 p-3 sm:p-4 bg-muted/50 border rounded-lg">
                 <div className="flex items-start gap-3">
                   <Bell className="h-4 w-4 text-foreground mt-0.5" />
                   <div className="space-y-1">
@@ -953,20 +953,20 @@ export default function SettingsPage({
             </CardContent>
           </Card>
 
-          {/* 🌐 구글 캘린더 연동 설정 */}
+          {/* � 모바일 최적화: �🌐 구글 캘린더 연동 설정 */}
           <Card className="border bg-card">
-            <CardHeader>
-              <CardTitle className="flex items-center gap-3 text-lg font-semibold">
+            <CardHeader className="p-4 sm:p-6 pb-3 sm:pb-4">
+              <CardTitle className="flex items-center gap-3 text-base sm:text-lg font-semibold">
                 <div className="p-2 bg-muted rounded-lg">
-                  <Calendar className="h-5 w-5 text-foreground" />
+                  <Calendar className="h-4 w-4 sm:h-5 sm:w-5 text-foreground" />
                 </div>
                 구글 캘린더 연동
               </CardTitle>
-              <CardDescription>
+              <CardDescription className="text-sm">
                 구글 캘린더와 SureCRM을 연동하여 일정을 통합 관리하세요
               </CardDescription>
             </CardHeader>
-            <CardContent className="p-6 space-y-6">
+            <CardContent className="p-4 sm:p-6 pt-0 space-y-5 sm:space-y-6">
               {/* 연동 상태 표시 */}
               <div className="flex items-center justify-between p-4 bg-muted/30 rounded-lg border">
                 <div className="flex items-center gap-3">
@@ -1303,31 +1303,31 @@ export default function SettingsPage({
           </Card>
         </div>
 
-        {/* 계정 정보 및 시스템 설정 */}
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-          {/* 계정 정보 */}
+        {/* 🎯 모바일 최적화: 계정 정보 및 시스템 설정 */}
+        <div className="grid grid-cols-1 xl:grid-cols-2 gap-4 sm:gap-6">
+          {/* 🎯 모바일 최적화: 계정 정보 */}
           <Card className="border bg-card">
-            <CardHeader>
-              <CardTitle className="flex items-center gap-3 text-lg font-semibold">
+            <CardHeader className="p-4 sm:p-6 pb-3 sm:pb-4">
+              <CardTitle className="flex items-center gap-3 text-base sm:text-lg font-semibold">
                 <div className="p-2 bg-muted rounded-lg">
-                  <User className="h-5 w-5 text-foreground" />
+                  <User className="h-4 w-4 sm:h-5 sm:w-5 text-foreground" />
                 </div>
                 계정 정보
               </CardTitle>
             </CardHeader>
-            <CardContent className="p-6 space-y-4">
+            <CardContent className="p-4 sm:p-6 pt-0 space-y-4">
               <div className="space-y-3">
-                <div className="flex items-center justify-between py-2 border-b border-border/50">
+                <div className="flex items-center justify-between py-2 border-b border-border/50 min-h-[44px]">
                   <div className="flex items-center gap-2">
                     <User className="h-4 w-4 text-muted-foreground" />
                     <span className="text-sm font-medium">사용자 ID</span>
                   </div>
-                  <code className="text-xs bg-muted px-2 py-1 rounded font-mono">
+                  <code className="text-xs sm:text-sm bg-muted px-2 py-1 rounded font-mono">
                     {userProfile.id.slice(0, 8)}...
                   </code>
                 </div>
 
-                <div className="flex items-center justify-between py-2 border-b border-border/50">
+                <div className="flex items-center justify-between py-2 border-b border-border/50 min-h-[44px]">
                   <div className="flex items-center gap-2">
                     <Calendar className="h-4 w-4 text-muted-foreground" />
                     <span className="text-sm font-medium">가입일</span>
@@ -1337,7 +1337,7 @@ export default function SettingsPage({
                   </span>
                 </div>
 
-                <div className="flex items-center justify-between py-2">
+                <div className="flex items-center justify-between py-2 min-h-[44px]">
                   <div className="flex items-center gap-2">
                     <Crown className="h-4 w-4 text-muted-foreground" />
                     <span className="text-sm font-medium">플랜</span>
@@ -1350,19 +1350,19 @@ export default function SettingsPage({
             </CardContent>
           </Card>
 
-          {/* 도움말 및 가이드 */}
+          {/* 🎯 모바일 최적화: 도움말 및 가이드 */}
           <Card className="border bg-card">
-            <CardHeader>
-              <CardTitle className="flex items-center gap-3 text-lg font-semibold">
+            <CardHeader className="p-4 sm:p-6 pb-3 sm:pb-4">
+              <CardTitle className="flex items-center gap-3 text-base sm:text-lg font-semibold">
                 <div className="p-2 bg-muted rounded-lg">
-                  <SettingsIcon className="h-5 w-5 text-foreground" />
+                  <SettingsIcon className="h-4 w-4 sm:h-5 sm:w-5 text-foreground" />
                 </div>
                 설정 가이드
               </CardTitle>
             </CardHeader>
-            <CardContent className="p-6 space-y-4">
+            <CardContent className="p-4 sm:p-6 pt-0 space-y-4">
               <div className="space-y-3">
-                <div className="flex items-start gap-3">
+                <div className="flex items-start gap-3 min-h-[44px]">
                   <div className="p-1 bg-primary/10 rounded">
                     <Save className="h-3 w-3 text-primary" />
                   </div>
@@ -1376,7 +1376,7 @@ export default function SettingsPage({
                   </div>
                 </div>
 
-                <div className="flex items-start gap-3">
+                <div className="flex items-start gap-3 min-h-[44px]">
                   <div className="p-1 bg-orange/10 rounded">
                     <Shield className="h-3 w-3 text-orange-600" />
                   </div>
@@ -1390,7 +1390,7 @@ export default function SettingsPage({
                   </div>
                 </div>
 
-                <div className="flex items-start gap-3">
+                <div className="flex items-start gap-3 min-h-[44px]">
                   <div className="p-1 bg-blue/10 rounded">
                     <User className="h-3 w-3 text-blue-600" />
                   </div>


### PR DESCRIPTION
Responsive design was implemented across the '초대장 관리', '알림', '보고서', and '설정' pages to optimize for mobile and tablet screen sizes.

*   `app/features/invitations/pages/invitations-page.tsx`: The recommendation guide was made collapsible using `Collapsible` to improve information hierarchy. Grid layouts were adjusted to `grid-cols-1 sm:grid-cols-2`.
*   `app/features/notifications/pages/notifications-page.tsx`: Top summary cards now use an adaptive grid (`grid-cols-1 sm:grid-cols-2 lg:grid-cols-3`). Header elements were reordered to `flex-col sm:flex-row`, and channel badges are hidden on mobile for progressive disclosure.
*   `app/features/reports/pages/reports-page.tsx`: The header layout was changed to `flex-col sm:flex-row`. The download button text was truncated to "저장" on mobile for brevity.
*   `app/features/settings/pages/settings-page.tsx`: Main setting cards were adjusted to `grid-cols-1 xl:grid-cols-2`.

Across all pages, interactive elements like buttons and input fields were given a `min-h-[44px]` for improved touch interaction. Padding, text, and icon sizes were scaled using responsive Tailwind CSS classes to enhance readability and visual balance on various devices. A `import * as React from 'react'